### PR TITLE
Variant importer should create a separate record for every alternate allele

### DIFF
--- a/tests/cases/commands/tests.py
+++ b/tests/cases/commands/tests.py
@@ -185,7 +185,7 @@ class BigAutoFieldsTestCase(TestCase):
 
         new_result = Result.objects.create(
             id=two_hundred_billion, sample_id=new_sample.id,
-            variant_id=new_variant.id)
+            allele_1_id=new_variant.id)
 
         ResultScore.objects.create(
             id=1, result_id=new_result.id, rank=0, score=0)

--- a/vdw/samples/migrations/0035_auto__chg_field_resultscore_result__del_field_result_coverage_alt__del.py
+++ b/vdw/samples/migrations/0035_auto__chg_field_resultscore_result__del_field_result_coverage_alt__del.py
@@ -1,0 +1,326 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Renaming field 'Result.coverage_ref'
+        db.rename_column('sample_result', 'coverage_ref', 'coverage_1')
+
+        # Renaming field 'Result.coverage_alt' to 'Result.
+        db.rename_column('sample_result', 'coverage_alt', 'coverage_2')
+
+        # Renaming field 'Result.variant'
+        db.rename_column('sample_result', 'variant_id', 'allele_1_id')
+
+        # Adding field 'Result.allele_2'
+        db.add_column('sample_result', 'allele_2',
+                      self.gf('django.db.models.fields.related.ForeignKey')(related_name='results', null=True, db_column='allele_2_id', to=orm['variants.Variant']),
+                      keep_default=False)
+
+        # Alter unique constraint to include 'allele', fields
+        db.delete_unique('sample_result', ['sample_id', 'allele_1_id'])
+        db.create_unique('sample_result', ['sample_id', 'allele_1_id', 'allele_2_id'])
+
+    def backwards(self, orm):
+        # Removing unique constraint on 'Result', fields ['sample', 'allele_1', 'allele_2']
+        db.delete_unique('sample_result', ['sample_id', 'allele_1_id', 'allele_2_id'])
+        db.create_unique('sample_result', ['sample_id', 'allele_1_id'])
+
+        # Renaming field 'Result.coverage_1'
+        db.rename_column('sample_result', 'coverage_1', 'coverage_ref')
+
+        # Renaming field 'Result.coverage_2'
+        db.rename_column('sample_result', 'coverage_2', 'coverage_alt')
+
+        # Renaming field 'Result.allele_1'
+        db.rename_column('sample_result', 'allele_1_id', 'variant_id')
+
+        # Deleting field 'Result.allele_2'
+        db.delete_column('sample_result', 'allele_2_id')
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'genome.chromosome': {
+            'Meta': {'ordering': "['order']", 'object_name': 'Chromosome', 'db_table': "'chromosome'"},
+            'code': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '2'}),
+            'order': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'value': ('django.db.models.fields.CharField', [], {'max_length': '2', 'db_index': 'True'})
+        },
+        'genome.genome': {
+            'Meta': {'object_name': 'Genome', 'db_table': "'genome'"},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'released': ('django.db.models.fields.DateField', [], {'null': 'True'}),
+            'version': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'genome.genotype': {
+            'Meta': {'object_name': 'Genotype', 'db_table': "'genotype'"},
+            'code': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'order': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'value': ('django.db.models.fields.CharField', [], {'max_length': '3'})
+        },
+        'literature.pubmed': {
+            'Meta': {'object_name': 'PubMed', 'db_table': "'pubmed'"},
+            'pmid': ('django.db.models.fields.IntegerField', [], {'primary_key': 'True'})
+        },
+        'phenotypes.phenotype': {
+            'Meta': {'object_name': 'Phenotype', 'db_table': "'phenotype'"},
+            'articles': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['literature.PubMed']", 'symmetrical': 'False'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'hpo_id': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'term': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '1000'})
+        },
+        'samples.batch': {
+            'Meta': {'ordering': "('project', 'label')", 'unique_together': "(('project', 'name'),)", 'object_name': 'Batch', 'db_table': "'batch'"},
+            'count': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'investigator': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'notes': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'batches'", 'to': "orm['samples.Project']"}),
+            'published': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        'samples.cohort': {
+            'Meta': {'ordering': "('-order', 'name')", 'object_name': 'Cohort', 'db_table': "'cohort'"},
+            'allele_freq_modified': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'autocreated': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'batch': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['samples.Batch']", 'null': 'True', 'blank': 'True'}),
+            'count': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'order': ('django.db.models.fields.SmallIntegerField', [], {'default': '0'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['samples.Project']", 'null': 'True', 'blank': 'True'}),
+            'published': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'samples': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['samples.Sample']", 'through': "orm['samples.CohortSample']", 'symmetrical': 'False'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']", 'null': 'True', 'blank': 'True'})
+        },
+        'samples.cohortsample': {
+            'Meta': {'object_name': 'CohortSample', 'db_table': "'cohort_sample'"},
+            'added': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'object_set': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['samples.Cohort']", 'db_column': "'cohort_id'"}),
+            'removed': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'set_object': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['samples.Sample']", 'db_column': "'sample_id'"})
+        },
+        'samples.cohortvariant': {
+            'Meta': {'unique_together': "(('variant', 'cohort'),)", 'object_name': 'CohortVariant', 'db_table': "'cohort_variant'"},
+            'af': ('django.db.models.fields.FloatField', [], {'null': 'True', 'db_index': 'True'}),
+            'cohort': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['samples.Cohort']"}),
+            'id': ('vdw.core.models.BigAutoField', [], {'primary_key': 'True'}),
+            'variant': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'cohort_details'", 'to': "orm['variants.Variant']"})
+        },
+        'samples.person': {
+            'Meta': {'object_name': 'Person', 'db_table': "'person'"},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'mrn': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'notes': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'proband': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'relations': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['samples.Person']", 'through': "orm['samples.Relation']", 'symmetrical': 'False'}),
+            'sex': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'})
+        },
+        'samples.project': {
+            'Meta': {'unique_together': "(('name',),)", 'object_name': 'Project', 'db_table': "'project'"},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'notes': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'})
+        },
+        'samples.relation': {
+            'Meta': {'ordering': "('person', '-generation')", 'object_name': 'Relation', 'db_table': "'relation'"},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'generation': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'notes': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'family'", 'to': "orm['samples.Person']"}),
+            'relative': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'relative_of'", 'to': "orm['samples.Person']"}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '20'})
+        },
+        'samples.result': {
+            'Meta': {'unique_together': "(('sample', 'allele_1', 'allele_2'),)", 'object_name': 'Result', 'db_table': "'sample_result'"},
+            'allele_1': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['variants.Variant']", 'db_column': "'allele_1_id'"}),
+            'allele_2': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'results'", 'null': 'True', 'db_column': "'allele_2_id'", 'to': "orm['variants.Variant']"}),
+            'base_counts': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'baseq_rank_sum': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'coverage_1': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'coverage_2': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'downsampling': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'fisher_strand': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'genotype': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['genome.Genotype']", 'null': 'True', 'blank': 'True'}),
+            'genotype_quality': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'haplotype_score': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'homopolymer_run': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'id': ('vdw.core.models.BigAutoField', [], {'primary_key': 'True'}),
+            'in_dbsnp': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'mq': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'mq0': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'mq_rank_sum': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'notes': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'phred_scaled_likelihood': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'quality': ('django.db.models.fields.FloatField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'quality_by_depth': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'raw_read_depth': ('django.db.models.fields.IntegerField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'read_depth': ('django.db.models.fields.IntegerField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'read_pos_rank_sum': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'sample': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'results'", 'to': "orm['samples.Sample']"}),
+            'spanning_deletions': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'strand_bias': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'})
+        },
+        'samples.resultscore': {
+            'Meta': {'object_name': 'ResultScore', 'db_table': "'result_score'"},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'notes': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'rank': ('django.db.models.fields.IntegerField', [], {}),
+            'result': ('vdw.core.models.BigForeignKey', [], {'related_name': "'score'", 'unique': 'True', 'to': "orm['samples.Result']"}),
+            'score': ('django.db.models.fields.FloatField', [], {})
+        },
+        'samples.resultset': {
+            'Meta': {'unique_together': "(('sample', 'name'),)", 'object_name': 'ResultSet', 'db_table': "'result_set'"},
+            'count': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'results': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['samples.Result']", 'through': "orm['samples.ResultSetItem']", 'symmetrical': 'False'}),
+            'sample': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'result_sets'", 'to': "orm['samples.Sample']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"})
+        },
+        'samples.resultsetitem': {
+            'Meta': {'unique_together': "(('result', 'set'),)", 'object_name': 'ResultSetItem', 'db_table': "'result_set_item'"},
+            'added': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'removed': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'result': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['samples.Result']"}),
+            'set': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['samples.ResultSet']"})
+        },
+        'samples.sample': {
+            'Meta': {'ordering': "('project', 'batch', 'label')", 'unique_together': "(('batch', 'name', 'version'),)", 'object_name': 'Sample', 'db_table': "'sample'"},
+            'batch': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'samples'", 'to': "orm['samples.Batch']"}),
+            'bio_sample': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'count': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'md5': ('django.db.models.fields.CharField', [], {'max_length': '32', 'null': 'True', 'blank': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'notes': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'person': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'samples'", 'null': 'True', 'to': "orm['samples.Person']"}),
+            'phenotype_modified': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'samples'", 'to': "orm['samples.Project']"}),
+            'published': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'vcf_colname': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'version': ('django.db.models.fields.IntegerField', [], {})
+        },
+        'samples.samplemanifest': {
+            'Meta': {'object_name': 'SampleManifest', 'db_table': "'sample_manifest'"},
+            'content': ('django.db.models.fields.TextField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'notes': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'path': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'sample': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'manifest'", 'unique': 'True', 'to': "orm['samples.Sample']"})
+        },
+        'samples.samplerun': {
+            'Meta': {'object_name': 'SampleRun', 'db_table': "'sample_run'"},
+            'completed': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'genome': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['genome.Genome']", 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'notes': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'sample': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['samples.Sample']"})
+        },
+        'variants.variant': {
+            'Meta': {'unique_together': "(('chr', 'pos', 'ref', 'alt'),)", 'object_name': 'Variant', 'db_table': "'variant'"},
+            'alt': ('django.db.models.fields.TextField', [], {'db_index': 'True'}),
+            'articles': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['literature.PubMed']", 'db_table': "'variant_pubmed'", 'symmetrical': 'False'}),
+            'chr': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['genome.Chromosome']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'liftover': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'md5': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'phenotypes': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['phenotypes.Phenotype']", 'through': "orm['variants.VariantPhenotype']", 'symmetrical': 'False'}),
+            'pos': ('django.db.models.fields.IntegerField', [], {}),
+            'ref': ('django.db.models.fields.TextField', [], {'db_index': 'True'}),
+            'rsid': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['variants.VariantType']", 'null': 'True'})
+        },
+        'variants.variantphenotype': {
+            'Meta': {'object_name': 'VariantPhenotype', 'db_table': "'variant_phenotype'"},
+            'hgmd_id': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '30', 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'phenotype': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['phenotypes.Phenotype']"}),
+            'variant': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'variant_phenotypes'", 'to': "orm['variants.Variant']"})
+        },
+        'variants.varianttype': {
+            'Meta': {'ordering': "['order']", 'object_name': 'VariantType', 'db_table': "'variant_type'"},
+            'code': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'order': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'value': ('django.db.models.fields.CharField', [], {'max_length': '20'})
+        }
+    }
+
+    complete_apps = ['samples']

--- a/vdw/samples/pipeline/utils.py
+++ b/vdw/samples/pipeline/utils.py
@@ -21,9 +21,9 @@ class ResultStream(VCFPGCopyEditor):
                       'spanning_deletions', 'mq', 'mq0', 'baseq_rank_sum',
                       'mq_rank_sum', 'read_pos_rank_sum', 'strand_bias',
                       'homopolymer_run', 'haplotype_score', 'quality_by_depth',
-                      'fisher_strand', 'base_counts', 'variant_id',
+                      'fisher_strand', 'base_counts', 'allele_1_id',
                       'sample_id', 'read_depth', 'quality', 'genotype_id',
-                      'genotype_quality', 'coverage_ref', 'coverage_alt',
+                      'genotype_quality', 'coverage_1', 'coverage_2',
                       'phred_scaled_likelihood', 'created', 'modified')
 
     def __init__(self, *args, **kwargs):
@@ -45,22 +45,12 @@ class ResultStream(VCFPGCopyEditor):
         # Calculate the MD5 of the variant itself (not the record)
         md5 = calculate_md5(record)
 
-        # Ensure the variant exists
-        variant_id = self.variants.get(md5)
-        assert variant_id is not None
-
         cleaned = super(ResultStream, self).process_line(record)
         # Remove variant specific parts
         cleaned = cleaned[4:]
 
         # can these be indexed?
         call = record.genotype(self.vcf_sample)
-
-        # Already seen this variant for this sample, otherwise we would get a
-        # duplicate key value violation in sample_result.
-        if Result.objects.filter(
-                variant=variant_id, sample=self.sample_id).exists():
-            return None
 
         # The possibility for multiple alleles in these wide vcfs is almost
         # infinite so we need to triage the really weird ones into having a
@@ -90,8 +80,22 @@ class ResultStream(VCFPGCopyEditor):
         if pl:
             pl = ','.join([str(x) for x in pl])
 
+        # Ensure the variant exists.
+        variant_id = self.variants.get(md5)
+        if variant_id is None:
+            log.debug("missing Variant in cache when processing line for "
+                      "ResultStream")
+            raise ValueError("missing Variant in cache")
+
+        # Already seen this variant for this sample, otherwise we would get a
+        # duplicate key value violation in sample_result.
+        if Result.objects.filter(
+                allele_1=variant_id, sample=self.sample_id).exists():
+            return None
+
         # Append remaining columns
-        other = [variant_id, self.sample_id, dp, record.QUAL, keyed_geno, gq,
+        other = [variant_id, self.sample_id, dp, record.QUAL,
+                 keyed_geno, gq,
                  ad0, ad1, pl, self.now, self.now]
 
         cleaned.extend([self.process_column('', x) for x in other])

--- a/vdw/variants/utils.py
+++ b/vdw/variants/utils.py
@@ -4,10 +4,25 @@ from vcf.model import _Record
 MD5_ARG_DELIMITER = '|'
 
 
-def calculate_md5(*args):
+def calculate_md5(*args, **kwargs):
+    alt_index = alt_value = None
+    if 'alt_value' in kwargs:
+        alt_value = kwargs['alt_value']
+    if 'alt_index' in kwargs:
+        alt_index = kwargs['alt_index']
+    if alt_value and alt_index:
+        raise ValueError("Both alt_value and alt_index were supplied when "
+                         "calculating a hash.  The alternate allele should "
+                         "be identified using only one of these methods.")
     if len(args) == 1 and isinstance(args[0], _Record):
         r = args[0]
-        values = [r.CHROM, r.POS, r.REF, ','.join([str(x) for x in r.ALT])]
+
+        if not alt_value:
+            if alt_index:
+                alt_value = r.ALT[alt_index]
+            else:
+                alt_value = ','.join([str(x) for x in r.ALT])
+        values = [r.CHROM, r.POS, r.REF, alt_value]
     elif len(args) == 4:
         values = list(args)
     else:


### PR DESCRIPTION
Currently, alternate allele data, including sequences and coverage are being truncated for variant rows with multiple alternate alleles.  As an interim measure, this can be mitigated by treating every alternate allele as a variant in itself, and adding a separate row to the variants table for it.

This would require an additional foreign key on the variant_result table, allowing samples that are heterozygous alternate at a given locus to point to a variant record for each allele.

The allelic depth fields should be renamed, as they would no longer be dedicated to ref and alt, but would rather refer to their respective homologous sequences at a given locus.
