### PR TITLE
Add signal to support additional foreign keys on Sample

### DIFF
--- a/vdw/samples/management/subcommands/delete_project.py
+++ b/vdw/samples/management/subcommands/delete_project.py
@@ -3,6 +3,8 @@ from optparse import make_option
 from django.core.management.base import BaseCommand, CommandError
 from django.db import connections, transaction, DEFAULT_DB_ALIAS, DatabaseError
 from vdw.assessments.models import Assessment
+from vdw.samples.models import Project
+from vdw.signals import pre_delete_project
 
 log = logging.getLogger(__name__)
 
@@ -109,6 +111,10 @@ class Command(BaseCommand):
                             WHERE project.id = %s
                     )
                 ''', [project_id])
+
+                # Alert listeners to project deletion.
+                pre_delete_project.send(
+                    sender=Project, pk=project_id, cursor=cursor)
 
                 # Remove samples
                 cursor.execute('''

--- a/vdw/samples/management/subcommands/delete_sample.py
+++ b/vdw/samples/management/subcommands/delete_sample.py
@@ -3,6 +3,7 @@ from optparse import make_option
 from django.core.management.base import BaseCommand, CommandError
 from django.db import connections, transaction, DEFAULT_DB_ALIAS, DatabaseError
 from vdw.samples.models import Sample
+from vdw.signals import pre_delete_sample
 
 log = logging.getLogger(__name__)
 
@@ -69,7 +70,9 @@ class Command(BaseCommand):
                     DELETE FROM sample_manifest WHERE sample_id IN ({0})
                 '''.format(columns), valid_ids)
 
-                # Remove sample
+                pre_delete_sample.send(
+                    sender=Sample, pk_set=valid_ids, cursor=cursor)
+
                 cursor.execute('''
                     DELETE FROM sample WHERE sample.id IN ({0})
                 '''.format(columns), valid_ids)

--- a/vdw/signals.py
+++ b/vdw/signals.py
@@ -1,0 +1,4 @@
+from django.dispatch import Signal
+
+pre_delete_sample = Signal(providing_args=['pk_set', 'cursor'])
+pre_delete_project = Signal(providing_args=['pk', 'cursor'])


### PR DESCRIPTION
This allows the delete-sample command to be extended, to support models with foreign keys pointing to Sample.
